### PR TITLE
Fixed problem with getting regions

### DIFF
--- a/ValNuget/websocket.cs
+++ b/ValNuget/websocket.cs
@@ -89,19 +89,19 @@ namespace ValAPINet
             IRestResponse RegResp = RegClient.Post(RegRequest);
             var regobj = JObject.Parse(RegResp.Content);
             string reg = (string)regobj["affinities"]["live"];
-            if (reg == "NA")
+            if (reg == "na")
             {
                 au.region = Region.NA;
             }
-            else if (reg == "AP")
+            else if (reg == "ap")
             {
                 au.region = Region.AP;
             }
-            else if (reg == "EU")
+            else if (reg == "eu")
             {
                 au.region = Region.EU;
             }
-            else if (reg == "KO")
+            else if (reg == "ko")
             {
                 au.region = Region.KO;
             }


### PR DESCRIPTION
Regions are listed in lower case letters, not capital letters.
Here is the actual response data:
```json
{
	"affinities": {
		"live": "ap",
		"pbe": "na"
	},
	"expiry": 1674320296,
	"issuedAt": 1674318496,
	"product": "valorant",
	"puuid": "hidden",
	"source": "serverAuthoritative",
	"token": "hidden"
}
```